### PR TITLE
SWIK-983 Update themes for general use

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -89,7 +89,7 @@ We added
     font-size: 2.285rem;
 }
 
-.reveal td, .reveal small{
+.reveal td, .reveal small, .reveal pre{
     font-size: 1.714rem;
 }
 
@@ -139,65 +139,65 @@ pptx2html.
 	*/
 }
 
-.reveal .slides section div.v-up {
+.reveal .slides section .v-up {
 	justify-content: flex-start;
 }
-.reveal .slides section div.v-mid {
+.reveal .slides section .v-mid {
 	justify-content: center;
 }
-.reveal .slides section div.v-down {
+.reveal .slides section .v-down {
 	justify-content: flex-end;
 }
 
-.reveal .slides section div.h-left {
+.reveal .slides section .h-left {
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.h-mid {
+.reveal .slides section .h-mid {
 	align-items: center;
 	text-align: center;
 }
-.reveal .slides section div.h-right {
+.reveal .slides section .h-right {
 	align-items: flex-end;
 	text-align: right;
 }
 
-.reveal .slides section div.up-left {
+.reveal .slides section .up-left {
 	justify-content: flex-start;
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.up-center {
+.reveal .slides section .up-center {
 	justify-content: flex-start;
 	align-items: center;
 }
-.reveal .slides section div.up-right {
+.reveal .slides section .up-right {
 	justify-content: flex-start;
 	align-items: flex-end;
 }
-.reveal .slides section div.center-left {
+.reveal .slides section .center-left {
 	justify-content: center;
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.center-center {
+.reveal .slides section .center-center {
 	justify-content: center;
 	align-items: center;
 }
-.reveal .slides section div.center-right {
+.reveal .slides section .center-right {
 	justify-content: center;
 	align-items: flex-end;
 }
-.reveal .slides section div.down-left {
+.reveal .slides section .down-left {
 	justify-content: flex-end;
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.down-center {
+.reveal .slides section .down-center {
 	justify-content: flex-end;
 	align-items: center;
 }
-.reveal .slides section div.down-right {
+.reveal .slides section .down-right {
 	justify-content: flex-end;
 	align-items: flex-end;
 }

--- a/css/reveal.css
+++ b/css/reveal.css
@@ -136,65 +136,65 @@ pptx2html.
 	*/
 }
 
-.reveal .slides section div.v-up {
+.reveal .slides section .v-up {
 	justify-content: flex-start;
 }
-.reveal .slides section div.v-mid {
+.reveal .slides section .v-mid {
 	justify-content: center;
 }
-.reveal .slides section div.v-down {
+.reveal .slides section .v-down {
 	justify-content: flex-end;
 }
 
-.reveal .slides section div.h-left {
+.reveal .slides section .h-left {
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.h-mid {
+.reveal .slides section .h-mid {
 	align-items: center;
 	text-align: center;
 }
-.reveal .slides section div.h-right {
+.reveal .slides section .h-right {
 	align-items: flex-end;
 	text-align: right;
 }
 
-.reveal .slides section div.up-left {
+.reveal .slides section .up-left {
 	justify-content: flex-start;
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.up-center {
+.reveal .slides section .up-center {
 	justify-content: flex-start;
 	align-items: center;
 }
-.reveal .slides section div.up-right {
+.reveal .slides section .up-right {
 	justify-content: flex-start;
 	align-items: flex-end;
 }
-.reveal .slides section div.center-left {
+.reveal .slides section .center-left {
 	justify-content: center;
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.center-center {
+.reveal .slides section .center-center {
 	justify-content: center;
 	align-items: center;
 }
-.reveal .slides section div.center-right {
+.reveal .slides section .center-right {
 	justify-content: center;
 	align-items: flex-end;
 }
-.reveal .slides section div.down-left {
+.reveal .slides section .down-left {
 	justify-content: flex-end;
 	align-items: flex-start;
 	text-align: left;
 }
-.reveal .slides section div.down-center {
+.reveal .slides section .down-center {
 	justify-content: flex-end;
 	align-items: center;
 }
-.reveal .slides section div.down-right {
+.reveal .slides section .down-right {
 	justify-content: flex-end;
 	align-items: flex-end;
 }

--- a/css/reveal.css
+++ b/css/reveal.css
@@ -67,12 +67,16 @@ Setting some defaults here, rather than replicating in each different theme
 white.css still has defaults, because it has been used in old decks
 */
 
-.reveal h3 {
+/*
+We added
+*/
+
+.reveal h1, .reveal h3 {
   font-size: 3.857rem;
   font-weight: bold;
 }
 
-.reveal h4 {
+.reveal h2, .reveal h4 {
   font-size: 3rem;
   font-weight: bold;
 }
@@ -84,7 +88,6 @@ white.css still has defaults, because it has been used in old decks
 .reveal p, .reveal li{
     font-size: 2.285rem;
 }
-
 
 .reveal td, .reveal small{
     font-size: 1.714rem;

--- a/css/reveal.css
+++ b/css/reveal.css
@@ -86,7 +86,7 @@ white.css still has defaults, because it has been used in old decks
 }
 
 
-.reveal td, .reveal small{
+.reveal td, .reveal small, .reveal caption{
     font-size: 1.714rem;
 }
 

--- a/css/theme/beige.css
+++ b/css/theme/beige.css
@@ -51,7 +51,7 @@
   font-weight: normal;
   line-height: 1.2;
   letter-spacing: normal;
-  text-transform: uppercase;
+  /*text-transform: uppercase;*/
   text-shadow: none;
   word-wrap: break-word; }
 

--- a/css/theme/beige.css
+++ b/css/theme/beige.css
@@ -22,7 +22,7 @@
 .reveal {
   font-family: "Lato", sans-serif;
   /*font-size: 36px;*/
-  font-size: 24px;
+  /*font-size: 24px;*/
   font-weight: normal;
   color: #333; }
 
@@ -55,6 +55,8 @@
   text-shadow: none;
   word-wrap: break-word; }
 
+/*
+Sizes are defined in reveal.css - HF
 .reveal h1 {
   font-size: 3.77em; }
 
@@ -65,9 +67,9 @@
   font-size: 1.55em; }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 20px 20px rgba(0, 0, 0, 0.15); }
 
 /*********************************************
@@ -150,7 +152,8 @@
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -200,7 +203,7 @@
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /*font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 
@@ -248,7 +251,7 @@
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #8b743d;
+  /*border-color: #8b743d;*/
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
 
 /*********************************************

--- a/css/theme/black.css
+++ b/css/theme/black.css
@@ -19,7 +19,7 @@ section.has-light-background, section.has-light-background h1, section.has-light
   background: #222;
   background-color: #222;
   font-family: "Source Sans Pro", Helvetica, sans-serif;
-  font-size: 38px;
+  /*font-size: 38px;*/
   font-weight: normal;
   color: #fff; }
 
@@ -52,7 +52,7 @@ section.has-light-background, section.has-light-background h1, section.has-light
   text-shadow: none;
   word-wrap: break-word; }
 
-.reveal h1 {
+/*.reveal h1 {
   font-size: 2.5em; }
 
 .reveal h2 {
@@ -63,9 +63,9 @@ section.has-light-background, section.has-light-background h1, section.has-light
 }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: none; }
 
 /*********************************************
@@ -148,7 +148,7 @@ section.has-light-background, section.has-light-background h1, section.has-light
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;

--- a/css/theme/black.css
+++ b/css/theme/black.css
@@ -48,7 +48,8 @@ section.has-light-background, section.has-light-background h1, section.has-light
   font-weight: 600;
   line-height: 1.2;
   letter-spacing: normal;
-  text-transform: uppercase;
+  /* Was requested we remove this in SWIK-1071. Doing for all themes - HF*/
+  /*text-transform: uppercase;*/
   text-shadow: none;
   word-wrap: break-word; }
 

--- a/css/theme/blood.css
+++ b/css/theme/blood.css
@@ -51,6 +51,7 @@
   font-weight: normal;
   line-height: 1.2;
   letter-spacing: normal;
+  /* Was requested we remove this in SWIK-1071. Doing for all themes - HF*/
   /*text-transform: uppercase;*/
   text-shadow: 2px 2px 2px #222;
   word-wrap: break-word; }

--- a/css/theme/blood.css
+++ b/css/theme/blood.css
@@ -55,7 +55,9 @@
   text-shadow: 2px 2px 2px #222;
   word-wrap: break-word; }
 
-/*.reveal h1 {
+/*
+Sizes are defined in reveal.css - HF
+.reveal h1 {
   font-size: 3.77em; }
 
 .reveal h2 {
@@ -67,7 +69,7 @@
 .reveal h4 {
   font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 20px 20px rgba(0, 0, 0, 0.15); }
 
 /*********************************************
@@ -151,7 +153,7 @@
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -202,7 +204,7 @@
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /*font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 

--- a/css/theme/default.css
+++ b/css/theme/default.css
@@ -46,8 +46,8 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   font-weight: 600;
   line-height: 1.2;
   letter-spacing: normal;
-  /* Reported in SWIK-
-  text-transform: uppercase;*/
+  /* Was requested we remove this in SWIK-1071. Doing for all themes - HF*/
+  /*text-transform: uppercase;*/
   text-shadow: none;
   word-wrap: break-word; }
 

--- a/css/theme/default.css
+++ b/css/theme/default.css
@@ -1,0 +1,311 @@
+/**
+ * White theme for reveal.js. This is the opposite of the 'black' theme.
+ *
+ * By Hakim El Hattab, http://hakim.se
+ */
+@import url(../../lib/font/source-sans-pro/source-sans-pro.css);
+section.has-dark-background, section.has-dark-background h1, section.has-dark-background h2, section.has-dark-background h3, section.has-dark-background h4, section.has-dark-background h5, section.has-dark-background h6 {
+  color: #fff; }
+
+/*********************************************
+ * GLOBAL STYLES
+ *********************************************/
+/*body {
+  background: #fff;
+  background-color: #fff; }*/
+
+.reveal {
+  font-family: "Source Sans Pro", Helvetica, sans-serif;
+  /*font-size: 38px;*/
+  font-size: 24px;
+  font-weight: normal;
+  color: #222; }
+
+.reveal ::selection {
+  color: #fff;
+  background: #98bdef;
+  text-shadow: none; }
+
+/**.reveal .slides > section,
+.reveal .slides > section > section {
+  line-height: 1.3;
+  font-weight: inherit; }**/
+
+/*********************************************
+ * HEADERS
+ *********************************************/
+.reveal h1,
+.reveal h2,
+.reveal h3,
+.reveal h4,
+.reveal h5,
+.reveal h6 {
+  margin: 0 0 20px 0;
+  color: #222;
+  font-family: "Source Sans Pro", Helvetica, sans-serif;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: normal;
+  /* Reported in SWIK-
+  text-transform: uppercase;*/
+  text-shadow: none;
+  word-wrap: break-word; }
+
+/* HF h1-  h6 are now specified in reveal.css. */
+/*.reveal h1 {
+  font-size: 2.5em; }
+
+.reveal h2 {
+  font-size: 1.6em; }
+
+.reveal h3 {
+  font-size: 1.3em; }
+
+.reveal h3 #titleText{
+    color: #000;
+    font-weight: initial;
+    font-style: normal;
+    text-decoration: initial;
+    vertical-align: ;
+}*/
+
+.reveal li{
+    color: #000;
+    /*font-size: 28pt;*/
+    font-family: Calibri;
+    font-weight: initial;
+    font-style: normal;
+    text-decoration: initial;
+    vertical-align: ;
+}
+
+/*.reveal h4 {
+  font-size: 1em; }*/
+
+.reveal h1 {
+  text-shadow: none; }
+
+/*********************************************
+ * OTHER
+ *********************************************/
+.reveal p {
+  margin: 20px 0;
+  line-height: 1.3; }
+
+/* Ensure certain elements are never larger than the slide itself */
+.reveal img,
+.reveal video,
+.reveal iframe {
+  max-width: 95%;
+  max-height: 95%; }
+
+.reveal strong,
+.reveal b {
+  font-weight: bold; }
+
+.reveal em {
+  font-style: italic; }
+
+.reveal ol,
+.reveal dl,
+.reveal ul {
+  display: inline-block;
+  text-align: left;
+  margin: 0 0 0 1em; }
+
+.reveal ol {
+  list-style-type: decimal; }
+
+.reveal ul {
+  list-style-type: disc; }
+
+.reveal ul ul {
+  list-style-type: square; }
+
+.reveal ul ul ul {
+  list-style-type: circle; }
+
+.reveal ul ul,
+.reveal ul ol,
+.reveal ol ol,
+.reveal ol ul {
+  display: block;
+  margin-left: 40px; }
+
+.reveal dt {
+  font-weight: bold; }
+
+.reveal dd {
+  margin-left: 40px; }
+
+.reveal q,
+.reveal blockquote {
+  quotes: none; }
+
+.reveal blockquote {
+  display: block;
+  position: relative;
+  width: 70%;
+  margin: 20px auto;
+  padding: 5px;
+  font-style: italic;
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2); }
+
+.reveal blockquote p:first-child,
+.reveal blockquote p:last-child {
+  display: inline-block; }
+
+.reveal q {
+  font-style: italic; }
+
+.reveal pre {
+  display: block;
+  position: relative;
+  width: 90%;
+  margin: 20px auto;
+  text-align: left;
+  font-size: 0.55em;
+  font-family: monospace;
+  line-height: 1.2em;
+  word-wrap: break-word;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
+
+.reveal code {
+  font-family: monospace; }
+
+.reveal pre code {
+  display: block;
+  padding: 5px;
+  overflow: auto;
+  max-height: 400px;
+  word-wrap: normal; }
+
+.reveal table {
+  margin: auto;
+  border-collapse: collapse;
+  border-spacing: 0; }
+
+.reveal table th {
+  font-weight: bold; }
+
+.reveal table th,
+.reveal table td {
+  text-align: left;
+  padding: 0.2em 0.5em 0.2em 0.5em;
+  border-bottom: 1px solid; }
+
+.reveal table th[align="center"],
+.reveal table td[align="center"] {
+  text-align: center; }
+
+.reveal table th[align="right"],
+.reveal table td[align="right"] {
+  text-align: right; }
+
+.reveal table tbody tr:last-child th,
+.reveal table tbody tr:last-child td {
+  border-bottom: none; }
+
+.reveal sup {
+  vertical-align: super; }
+
+.reveal sub {
+  vertical-align: sub; }
+
+.reveal small {
+  display: inline-block;
+  /* font-size now specified in reveal.css - HF */
+  /*font-size: 0.6em;*/
+  line-height: 1.2em;
+  vertical-align: top; }
+
+.reveal small * {
+  vertical-align: top; }
+
+/*********************************************
+ * LINKS
+ *********************************************/
+.reveal a {
+  color: #2a76dd;
+  text-decoration: none;
+  -webkit-transition: color .15s ease;
+  -moz-transition: color .15s ease;
+  transition: color .15s ease; }
+
+.reveal a:hover {
+  color: #6ca0e8;
+  text-shadow: none;
+  border: none; }
+
+.reveal .roll span:after {
+  color: #fff;
+  background: #1a53a1; }
+
+/*********************************************
+ * IMAGES
+ *********************************************/
+.reveal section img {
+  margin: 15px 0px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 0;
+  /*box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); */
+}
+
+.reveal section img.plain {
+  border: 0;
+  box-shadow: none; }
+
+.reveal a img {
+  -webkit-transition: all .15s linear;
+  -moz-transition: all .15s linear;
+  transition: all .15s linear; }
+
+.reveal a:hover img {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: #2a76dd;
+  /*box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); */
+}
+
+/*********************************************
+ * NAVIGATION CONTROLS
+ *********************************************/
+.reveal .controls .navigate-left,
+.reveal .controls .navigate-left.enabled {
+  border-right-color: #2a76dd; }
+
+.reveal .controls .navigate-right,
+.reveal .controls .navigate-right.enabled {
+  border-left-color: #2a76dd; }
+
+.reveal .controls .navigate-up,
+.reveal .controls .navigate-up.enabled {
+  border-bottom-color: #2a76dd; }
+
+.reveal .controls .navigate-down,
+.reveal .controls .navigate-down.enabled {
+  border-top-color: #2a76dd; }
+
+.reveal .controls .navigate-left.enabled:hover {
+  border-right-color: #6ca0e8; }
+
+.reveal .controls .navigate-right.enabled:hover {
+  border-left-color: #6ca0e8; }
+
+.reveal .controls .navigate-up.enabled:hover {
+  border-bottom-color: #6ca0e8; }
+
+.reveal .controls .navigate-down.enabled:hover {
+  border-top-color: #6ca0e8; }
+
+/*********************************************
+ * PROGRESS BAR
+ *********************************************/
+.reveal .progress {
+  background: rgba(0, 0, 0, 0.2); }
+
+.reveal .progress span {
+  background: #2a76dd;
+  -webkit-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+  -moz-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+  transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }

--- a/css/theme/default.css
+++ b/css/theme/default.css
@@ -26,10 +26,10 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   background: #98bdef;
   text-shadow: none; }
 
-/**.reveal .slides > section,
+.reveal .slides > section,
 .reveal .slides > section > section {
-  line-height: 1.3;
-  font-weight: inherit; }**/
+/*  line-height: 1.3;*/
+  font-weight: inherit; }
 
 /*********************************************
  * HEADERS
@@ -165,7 +165,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -263,7 +263,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #2a76dd;
+  /*border-color: #2a76dd;*/
   /*box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); */
 }
 

--- a/css/theme/league.css
+++ b/css/theme/league.css
@@ -23,7 +23,8 @@
 
 .reveal {
   font-family: "Lato", sans-serif;
-  font-size: 36px;
+  /* Sizes are defined in reveal.css - HF
+  font-size: 36px;*/
   font-weight: normal;
   color: #eee; }
 
@@ -34,7 +35,8 @@
 
 .reveal .slides > section,
 .reveal .slides > section > section {
-  line-height: 1.3;
+  /* Removing to make consistent with other themes
+  line-height: 1.3;*/
   font-weight: inherit; }
 
 /*********************************************
@@ -56,6 +58,7 @@
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   word-wrap: break-word; }
 
+/* Sizes are defined in reveal.css - HF
 .reveal h1 {
   font-size: 3.77em; }
 
@@ -66,9 +69,9 @@
   font-size: 1.55em; }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2), 0 5px 10px rgba(0, 0, 0, 0.25), 0 20px 20px rgba(0, 0, 0, 0.15); }
 
 /*********************************************
@@ -229,11 +232,14 @@
 
 /*********************************************
  * IMAGES
- *********************************************/
+ *********************************************
+Removed all borders - HF
+ */
+
 .reveal section img {
   margin: 15px 0px;
   background: rgba(255, 255, 255, 0.12);
-  border: 4px solid #eee;
+  /*border: 4px solid #eee;*/
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
 
 .reveal section img.plain {
@@ -247,7 +253,7 @@
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #13DAEC;
+  /*border-color: #13DAEC;*/
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
 
 /*********************************************

--- a/css/theme/league.css
+++ b/css/theme/league.css
@@ -54,7 +54,8 @@
   font-weight: normal;
   line-height: 1.2;
   letter-spacing: normal;
-  text-transform: uppercase;
+  /* Was requested we remove this in SWIK-1071. Doing for all themes - HF*/
+  /*text-transform: uppercase;*/
   text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);
   word-wrap: break-word; }
 

--- a/css/theme/moon.css
+++ b/css/theme/moon.css
@@ -20,7 +20,8 @@ html * {
 
 .reveal {
   font-family: "Lato", sans-serif;
-  font-size: 36px;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 36px;*/
   font-weight: normal;
   color: #93a1a1; }
 
@@ -31,7 +32,8 @@ html * {
 
 .reveal .slides > section,
 .reveal .slides > section > section {
-  line-height: 1.3;
+  /*Sizes are defined in reveal.css - HF
+  line-height: 1.3;*/
   font-weight: inherit; }
 
 /*********************************************
@@ -53,6 +55,7 @@ html * {
   text-shadow: none;
   word-wrap: break-word; }
 
+/*Sizes are defined in reveal.css - HF
 .reveal h1 {
   font-size: 3.77em; }
 
@@ -63,9 +66,9 @@ html * {
   font-size: 1.55em; }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: none; }
 
 /*********************************************
@@ -148,7 +151,8 @@ html * {
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -198,7 +202,8 @@ html * {
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 
@@ -230,7 +235,7 @@ html * {
 .reveal section img {
   margin: 15px 0px;
   background: rgba(255, 255, 255, 0.12);
-  border: 4px solid #93a1a1;
+  /*border: 4px solid #93a1a1;*/
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
 
 .reveal section img.plain {
@@ -244,7 +249,7 @@ html * {
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #268bd2;
+  /*border-color: #268bd2;*/
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
 
 /*********************************************

--- a/css/theme/moon.css
+++ b/css/theme/moon.css
@@ -51,7 +51,8 @@ html * {
   font-weight: normal;
   line-height: 1.2;
   letter-spacing: normal;
-  text-transform: uppercase;
+  /* Was requested we remove this in SWIK-1071. Doing for all themes - HF*/
+  /*text-transform: uppercase;*/
   text-shadow: none;
   word-wrap: break-word; }
 

--- a/css/theme/night.css
+++ b/css/theme/night.css
@@ -14,7 +14,8 @@
 
 .reveal {
   font-family: "Open Sans", sans-serif;
-  font-size: 30px;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 30px;*/
   font-weight: normal;
   color: #eee; }
 
@@ -25,7 +26,7 @@
 
 .reveal .slides > section,
 .reveal .slides > section > section {
-  line-height: 1.3;
+  /*line-height: 1.3;*/
   font-weight: inherit; }
 
 /*********************************************
@@ -47,6 +48,7 @@
   text-shadow: none;
   word-wrap: break-word; }
 
+/* Size now defined in reveal.css - HF
 .reveal h1 {
   font-size: 3.77em; }
 
@@ -57,9 +59,9 @@
   font-size: 1.55em; }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: none; }
 
 /*********************************************
@@ -142,7 +144,7 @@
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -192,7 +194,7 @@
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /*font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 
@@ -224,7 +226,8 @@
 .reveal section img {
   margin: 15px 0px;
   background: rgba(255, 255, 255, 0.12);
-  border: 4px solid #eee;
+  /* Removing border - HF */
+  border: 0;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
 
 .reveal section img.plain {
@@ -238,7 +241,7 @@
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #e7ad52;
+  /*border-color: #e7ad52;*/
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
 
 /*********************************************

--- a/css/theme/serif.css
+++ b/css/theme/serif.css
@@ -16,7 +16,8 @@
 
 .reveal {
   font-family: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;
-  font-size: 36px;
+  /* Sizes are defined in reveal.css - HF
+   font-size: 36px;*/
   font-weight: normal;
   color: #000; }
 
@@ -27,7 +28,7 @@
 
 .reveal .slides > section,
 .reveal .slides > section > section {
-  line-height: 1.3;
+  /*line-height: 1.3;*/
   font-weight: inherit; }
 
 /*********************************************
@@ -49,6 +50,7 @@
   text-shadow: none;
   word-wrap: break-word; }
 
+/* Sizes are defined in reveal.css - HF
 .reveal h1 {
   font-size: 3.77em; }
 
@@ -59,9 +61,9 @@
   font-size: 1.55em; }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: none; }
 
 /*********************************************
@@ -144,7 +146,8 @@
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /* Sizes are defined in reveal.css - HF
+  font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -194,7 +197,8 @@
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /* Sizes are defined in reveal.css - HF
+  font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 
@@ -226,7 +230,8 @@
 .reveal section img {
   margin: 15px 0px;
   background: rgba(255, 255, 255, 0.12);
-  border: 4px solid #000;
+  /* Removing border - HF */
+  border: 0;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
 
 .reveal section img.plain {
@@ -240,7 +245,7 @@
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #51483D;
+  /*border-color: #51483D;*/
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
 
 /*********************************************

--- a/css/theme/simple.css
+++ b/css/theme/simple.css
@@ -16,7 +16,8 @@
 
 .reveal {
   font-family: "Lato", sans-serif;
-  font-size: 36px;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 36px;*/
   font-weight: normal;
   color: #000; }
 
@@ -27,7 +28,7 @@
 
 .reveal .slides > section,
 .reveal .slides > section > section {
-  line-height: 1.3;
+  /*line-height: 1.3;*/
   font-weight: inherit; }
 
 /*********************************************
@@ -49,6 +50,7 @@
   text-shadow: none;
   word-wrap: break-word; }
 
+/*Sizes are defined in reveal.css - HF
 .reveal h1 {
   font-size: 3.77em; }
 
@@ -59,9 +61,9 @@
   font-size: 1.55em; }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: none; }
 
 /*********************************************
@@ -144,7 +146,8 @@
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -194,7 +197,8 @@
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 
@@ -226,7 +230,8 @@
 .reveal section img {
   margin: 15px 0px;
   background: rgba(255, 255, 255, 0.12);
-  border: 4px solid #000;
+  /* Removing border - HF*/
+  border: 0;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
 
 .reveal section img.plain {
@@ -240,7 +245,7 @@
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #00008B;
+  /*border-color: #00008B;*/
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
 
 /*********************************************

--- a/css/theme/sky.css
+++ b/css/theme/sky.css
@@ -11,7 +11,9 @@
 /*********************************************
  * GLOBAL STYLES
  *********************************************/
-/*body {
+/*
+Changed body to define in .reveal - HF
+body {
   background: #add9e4;
   background: -moz-radial-gradient(center, circle cover, #f7fbfc 0%, #add9e4 100%);
   background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(0%, #f7fbfc), color-stop(100%, #add9e4));
@@ -37,13 +39,14 @@
 
 .reveal ::selection {
   color: #fff;
-  background: #134674;
+  /*background: #134674;*/
   text-shadow: none; }
 
 
 .reveal .slides > section,
 .reveal .slides > section > section {
-  line-height: 1.3;
+  /*Removed for consistency - HF*/
+  /*line-height: 1.3;*/
   font-weight: inherit; }
 
 /*********************************************
@@ -65,6 +68,7 @@
   text-shadow: none;
   word-wrap: break-word; }
 
+/*Sizes are defined in reveal.css - HF
 .reveal h1 {
   font-size: 3.77em; }
 
@@ -75,9 +79,9 @@
   font-size: 1.55em; }
 
 .reveal h4 {
-  font-size: 1em; }
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: none; }
 
 /*********************************************
@@ -160,7 +164,8 @@
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*Sizes are defined in reveal.css - HF
+  font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -210,7 +215,8 @@
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /*Sizes are defined in reveal.css - HF*/
+  /*font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 
@@ -242,7 +248,8 @@
 .reveal section img {
   margin: 15px 0px;
   background: rgba(255, 255, 255, 0.12);
-  border: 4px solid #333;
+  /*removing border - HF*/
+  border: 0;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.15); }
 
 .reveal section img.plain {
@@ -256,7 +263,7 @@
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #3b759e;
+  /*border-color: #3b759e;*/
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
 
 /*********************************************

--- a/css/theme/sky.css
+++ b/css/theme/sky.css
@@ -64,7 +64,8 @@ body {
   font-weight: normal;
   line-height: 1.2;
   letter-spacing: -0.08em;
-  text-transform: uppercase;
+  /* Was requested we remove this in SWIK-1071. Doing for all themes - HF*/
+  /*text-transform: uppercase;*/
   text-shadow: none;
   word-wrap: break-word; }
 

--- a/css/theme/solarized.css
+++ b/css/theme/solarized.css
@@ -57,10 +57,10 @@ body {
   word-wrap: break-word; }
 
 
-.reveal h4 {
-  font-size: 1em; }
+/*.reveal h4 {
+  font-size: 1em; }*/
 
-.reveal h1 {
+.reveal h1, .reveal h3 {
   text-shadow: none; }
 
 /*********************************************
@@ -143,7 +143,7 @@ body {
   width: 90%;
   margin: 20px auto;
   text-align: left;
-  font-size: 0.55em;
+  /*font-size: 0.55em;*/
   font-family: monospace;
   line-height: 1.2em;
   word-wrap: break-word;
@@ -193,7 +193,8 @@ body {
 
 .reveal small {
   display: inline-block;
-  font-size: 0.6em;
+  /*Sizes now defined in reveal.css - HF*/
+  /*font-size: 0.6em;*/
   line-height: 1.2em;
   vertical-align: top; }
 
@@ -240,7 +241,7 @@ body {
 
 .reveal a:hover img {
   background: rgba(255, 255, 255, 0.2);
-  border-color: #268bd2;
+  /*border-color: #268bd2;*/
   /*box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); */
 }
 

--- a/css/theme/solarized.css
+++ b/css/theme/solarized.css
@@ -52,7 +52,8 @@ body {
   font-weight: normal;
   line-height: 1.2;
   letter-spacing: normal;
-  text-transform: uppercase;
+  /* Was requested we remove this in SWIK-1071. Doing for all themes - HF*/
+  /*text-transform: uppercase;*/
   text-shadow: none;
   word-wrap: break-word; }
 

--- a/css/theme/white.css
+++ b/css/theme/white.css
@@ -51,6 +51,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
   font-weight: 600;
   line-height: 1.2;
   letter-spacing: normal;
+  /*We're leaving text-transform as is for legacy themes*/
   text-transform: uppercase;
   text-shadow: none;
   word-wrap: break-word; }

--- a/css/theme/white.css
+++ b/css/theme/white.css
@@ -1,7 +1,12 @@
 /**
+We are keeping this as a legacy theme, for use of the themes which are already in use.
+Any changes to the "white" theme should be made in default.css
+*/
+
+/**
  * White theme for reveal.js. This is the opposite of the 'black' theme.
  *
- * By Hakim El Hattab, http://hakim.se
+ * By Hakim El Hattab, http://hakim.se *
  */
 @import url(../../lib/font/source-sans-pro/source-sans-pro.css);
 section.has-dark-background, section.has-dark-background h1, section.has-dark-background h2, section.has-dark-background h3, section.has-dark-background h4, section.has-dark-background h5, section.has-dark-background h6 {


### PR DESCRIPTION
Themes have been updated so that they have got rid of most of the bits we don't want on themes. Necessary for SWIK-1123.

Also includes a bugfix on reveal.css, where we appear to have lost some of the change for centre aligning title.