### PR TITLE
SWIK-2100 shortcut conflict

### DIFF
--- a/js/reveal.js
+++ b/js/reveal.js
@@ -235,18 +235,18 @@
 
 		// Holds information about the keyboard shortcuts
 		keyboardShortcuts = {
-			//SWIK-2100 Removed N and H due to conflicts - HF
+			//SWIK-2100 (HF) Removed N and H due to conflicts
+			// Removed references to up and down, and added speaker view
 			'SPACE':				'Next slide',
 			'P':					'Previous slide',
 			'&#8592;':				'Navigate left',
-			'&#8594;  ,  L':		'Navigate right',
-			'&#8593;  ,  K':		'Navigate up',
-			'&#8595;  ,  J':		'Navigate down',
+			'&#8594;':				'Navigate right',
 			'Home':					'First slide',
 			'End':					'Last slide',
 			'B  ,  .':				'Pause',
 			'F':					'Fullscreen',
-			'ESC, O':				'Slide overview'
+			'ESC, O':				'Slide overview',
+			'S': 					'Speaker view'
 		};
 
 	/**

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -235,6 +235,7 @@
 
 		// Holds information about the keyboard shortcuts
 		keyboardShortcuts = {
+			//SWIK-2100 Removed N and H due to conflicts - HF
 			'SPACE':				'Next slide',
 			'P':					'Previous slide',
 			'&#8592;':				'Navigate left',

--- a/js/reveal.js
+++ b/js/reveal.js
@@ -235,9 +235,9 @@
 
 		// Holds information about the keyboard shortcuts
 		keyboardShortcuts = {
-			'N  ,  SPACE':			'Next slide',
+			'SPACE':				'Next slide',
 			'P':					'Previous slide',
-			'&#8592;  ,  H':		'Navigate left',
+			'&#8592;':				'Navigate left',
 			'&#8594;  ,  L':		'Navigate right',
 			'&#8593;  ,  K':		'Navigate up',
 			'&#8595;  ,  J':		'Navigate down',


### PR DESCRIPTION
The shortcut keys N and H conflict with screen readers.  We removed thse from the help, and also tidied it a bit. Should be done with the PR #817 in platform