### PR TITLE
SWIK-2142 Changes margin on .slides to improve positioning

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -501,7 +501,8 @@ pptx2html.
   right: 0;
   bottom: 0;
   left: 0;
-  margin: auto;
+  /*SWIK-2142 Changed margin to only centre horizontally*/
+  margin: 0 auto;
   overflow: visible;
   z-index: 1;
   text-align: center;


### PR DESCRIPTION
With margin: auto, the content ends up pushed down still. Changed to margin: 0 auto;
Associated PR: #819 in platform