### PR TITLE
Swik-2026 thumbnail fonts

### DIFF
--- a/css/reveal.css
+++ b/css/reveal.css
@@ -28,6 +28,11 @@
   font: inherit;
   vertical-align: baseline; }*/
 
+/*
+SWIK-2124 Hack to convert Calibri to source sans pro - HF
+*/
+@import url(/custom_modules/reveal.js/lib/font/calibri/calibri.css);
+
 .reveal article, .reveal aside, .reveal details, .reveal figcaption, .reveal figure,
 .reveal footer, .reveal header, .reveal hgroup, .reveal menu, .reveal nav, .reveal section {
   display: block; }

--- a/css/theme/default.css
+++ b/css/theme/default.css
@@ -72,7 +72,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
 .reveal li{
     color: #000;
     /*font-size: 28pt;*/
-    font-family: sans-serif;
+    font-family: "Source Sans Pro", Helvetica, sans-serif;
     font-weight: initial;
     font-style: normal;
     text-decoration: initial;

--- a/css/theme/white.css
+++ b/css/theme/white.css
@@ -77,7 +77,7 @@ section.has-dark-background, section.has-dark-background h1, section.has-dark-ba
 .reveal li{
     color: #000;
     font-size: 28pt;
-    font-family: sans-serif;
+    font-family: "Source Sans Pro", Helvetica, sans-serif;
     font-weight: initial;
     font-style: normal;
     text-decoration: initial;

--- a/lib/font/calibri/calibri.css
+++ b/lib/font/calibri/calibri.css
@@ -1,0 +1,44 @@
+/*
+Hardcoded metadata of Calibri font comes in PPTX and copy/paste files
+By default it falls back to a serif font
+This takes Calibri and renders Source sans pro instead.
+*/
+@font-face {
+    font-family: 'Calibri';
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/-regular.eot');
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-regular.eot?#iefix') format('embedded-opentype'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-regular.woff') format('woff'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Calibri';
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-italic.eot');
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-italic.eot?#iefix') format('embedded-opentype'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-italic.woff') format('woff'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-italic.ttf') format('truetype');
+    font-weight: normal;
+    font-style: italic;
+}
+
+@font-face {
+    font-family: 'Calibri';
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibold.eot');
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibold.eot?#iefix') format('embedded-opentype'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibold.woff') format('woff'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibold.ttf') format('truetype');
+    font-weight: 600;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Calibri';
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibolditalic.eot');
+    src: url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibolditalic.eot?#iefix') format('embedded-opentype'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibolditalic.woff') format('woff'),
+         url('/custom_modules/reveal.js/lib/font/source-sans-pro/source-sans-pro-semibolditalic.ttf') format('truetype');
+    font-weight: 600;
+    font-style: italic;
+}


### PR DESCRIPTION
This deals specifically with calibri hardcoded into pptx and metadata from MS pasted into SlideWiki.  Uses font-face to convert any instance of calibri to source sans pro using the font files in the reveal.js package.

Note, previously the PR changed fonts to `sans-serif`, but this is different to the rest of the text. Now updated the li elements to be source sans pro as well, falling back to helvetica, sans serif (but this shouldn't happen because of font-face.

Existing thumbnails will have to be regenerated for this fix to apply to them